### PR TITLE
Prevent race-condition of two requests on same action with different route params

### DIFF
--- a/src/PostRedirectGet.php
+++ b/src/PostRedirectGet.php
@@ -64,14 +64,14 @@ class PostRedirectGet extends AbstractPlugin
     }
 
     /**
-     * 
+     *
      * @return string
      */
-    public function getContainerIdentifier(){
-        
+    public function getContainerIdentifier()
+    {
         $controller = $this->getController();
         $request    = $controller->getRequest();
-    
+
         return md5($request->getUri());
     }
 

--- a/src/PostRedirectGet.php
+++ b/src/PostRedirectGet.php
@@ -64,12 +64,24 @@ class PostRedirectGet extends AbstractPlugin
     }
 
     /**
+     * 
+     * @return string
+     */
+    public function getContainerIdentifier(){
+        
+        $controller = $this->getController();
+        $request    = $controller->getRequest();
+    
+        return md5($request->getRequestUri());
+    }
+
+    /**
      * @return Container
      */
     public function getSessionContainer()
     {
         if (! $this->sessionContainer) {
-            $this->sessionContainer = new Container('prg_post1');
+            $this->sessionContainer = new Container($this->getContainerIdentifier());
         }
         return $this->sessionContainer;
     }

--- a/src/PostRedirectGet.php
+++ b/src/PostRedirectGet.php
@@ -72,7 +72,7 @@ class PostRedirectGet extends AbstractPlugin
         $controller = $this->getController();
         $request    = $controller->getRequest();
     
-        return md5($request->getRequestUri());
+        return md5($request->getUri());
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I ran in this issue today because of a smart user who thought: 

> If I need to fill in the same information for different entities, I just open up each edit page in a 
> single tab, fill in the dates and then save, switch tab, save, switch tab, save, switch tab [...]

Due to lag it lead to the first POST request being sent, saved in session via the key 'prg_post1', then the second POST request came in, the prg-plugin found an existing container for 'prg_post1' although it was saved from the first request and processed it. 

This wouldn't be an issue it the identifier of the entity that this data should be processed for wasn't identified by a parameter in the route. 

To reproduce: 
1. create an action that produces a form, that gets handled via prg
2. call that action via a route containing a route-parameter e.g. /myAction/:id
3. check for route parameter and delay execution of redirect if param == A to simulate lag
4. Send form from action called with param = A, while request(A) is delayed, send form from action called with param = B

Expected:
Form from /myAction/A contains data sent from /myAction/A
Form from /myAction/B contains data sent from /myAction/B

Actual result:
Form from /myAction/B contains data sent from /myAction/A