### PR TITLE
use URI path instead of URI object to generate md5 for container identifier

### DIFF
--- a/src/PostRedirectGet.php
+++ b/src/PostRedirectGet.php
@@ -66,7 +66,7 @@ class PostRedirectGet extends AbstractPlugin
         $controller = $this->getController();
         $request    = $controller->getRequest();
 
-        return md5($request->getUri());
+        return md5($request->getUri()->getPath());
     }
 
     /**


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description
I'm running into an issue where the GET request isn't successful as the session container identifier differs to the POST request identifier. This is because the request's URI instance is used to generate the hash, but this changes from one request to another due to query params being passed in the second request.

This PR proposes using the URI path to generate the hash instead.

Cheers 🙂 



